### PR TITLE
Fixes the last compatible version of brakeman with this action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.1
+
+- Added the last compatible version of brakeman to the ruby from the container image
+
 ## v1.0.0
 
 - Create check run in github

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.6.5-alpine
 
-RUN gem install brakeman
+RUN gem install brakeman -v 5.4.1
 
 COPY lib /action/lib
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Brakeman is a static analysis tool which checks Ruby on Rails applications for s
 
 ```yml
 - name: Brakeman
-  uses: devmasx/brakeman-linter-action@v1.0.0
+  uses: devmasx/brakeman-linter-action@v1.0.1
   env:
     GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 ```
@@ -22,7 +22,7 @@ Brakeman is a static analysis tool which checks Ruby on Rails applications for s
   run: |
     brakeman -f json > tmp/brakeman.json || exit 0
 - name: Brakeman
-  uses: devmasx/brakeman-linter-action@v1.0.0
+  uses: devmasx/brakeman-linter-action@v1.0.1
   env:
     GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
     REPORT_PATH: tmp/brakeman.json
@@ -32,7 +32,7 @@ Brakeman is a static analysis tool which checks Ruby on Rails applications for s
 
 ```yml
 - name: Brakeman
-  uses: devmasx/brakeman-linter-action@v1.0.0
+  uses: devmasx/brakeman-linter-action@v1.0.1
   env:
     GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
     PROJECT_PATH: my_rails_app
@@ -51,7 +51,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Brakeman
-      uses: devmasx/brakeman-linter-action@v1.0.0
+      uses: devmasx/brakeman-linter-action@v1.0.1
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 ```


### PR DESCRIPTION
# bug fix

## Description

Yesterday, a new version of brakeman has been released and required at least the ruby 3.0, after that this action has broken. This pull request fixes with the last compatible version.

## Why should this be added

Avoid projects start failing and blocking other projects.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] Actions are passing
